### PR TITLE
reset pids on cmd initialize, static LED display

### DIFF
--- a/arduino/onrobotlights/onrobotlights.ino
+++ b/arduino/onrobotlights/onrobotlights.ino
@@ -17,7 +17,7 @@
 // Create a variable that will store the colors for the LEDs.
 CRGB leds[NUM_LEDS];
 
-int pattern = 0;
+int pattern = 4;
 
 void setup() {
   // Tell the FastLED library:
@@ -64,22 +64,22 @@ void setup() {
 }
 
 void loop() {
-  if (Serial.available() > 0) {
-    byte value = Serial.read();
-
-    // These byte values should match with values in
-    // ArduinoSubsystem.enumToByte()
-    if (value == 0x40) {
-      Serial.println("turning leds off");
-      pattern = 0;
-    } else if (value == 0x41) {
-      Serial.println("setting leds yellow");
-      pattern = 1;
-    } else if (value == 0x42) {
-      Serial.println("setting leds purple");
-      pattern = 2;
-    }
-  }
+//  if (Serial.available() > 0) {
+//    byte value = Serial.read();
+//
+//    // These byte values should match with values in
+//    // ArduinoSubsystem.enumToByte()
+//    if (value == 0x40) {
+//      Serial.println("turning leds off");
+//      pattern = 0;
+//    } else if (value == 0x41) {
+//      Serial.println("setting leds yellow");
+//      pattern = 1;
+//    } else if (value == 0x42) {
+//      Serial.println("setting leds purple");
+//      pattern = 2;
+//    }
+//  }
 
   if (pattern == 0) {
     off();

--- a/src/main/java/frc/robot/commands/Drive/TurnCmd.java
+++ b/src/main/java/frc/robot/commands/Drive/TurnCmd.java
@@ -31,6 +31,7 @@ public class TurnCmd extends CommandBase {
     drive.zeroencoders();
     drive.zeroyawnavx();
     drive.setdegree(degree);
+    pid.reset();
   }
 
   // Called every time the scheduler runs while the command is scheduled.

--- a/src/main/java/frc/robot/commands/OneBar/PID.java
+++ b/src/main/java/frc/robot/commands/OneBar/PID.java
@@ -24,6 +24,7 @@ public class PID extends CommandBase {
   @Override
   public void initialize() {
     setPoint = onebarsubsystem.getEncoder();
+    PIDo.reset();
   }
 
   // Called every time the scheduler runs while the command is scheduled.

--- a/src/main/java/frc/robot/commands/OneBar/PID2.java
+++ b/src/main/java/frc/robot/commands/OneBar/PID2.java
@@ -26,7 +26,9 @@ public class PID2 extends CommandBase {
 
   // Called when the command is initially scheduled
   @Override
-  public void initialize() {}
+  public void initialize() {
+    PIDo.reset();
+  }
 
   // Called every time the scheduler runs while the command is scheduled.
   @Override

--- a/src/main/java/frc/robot/commands/Wrist/AutoAlignCmd.java
+++ b/src/main/java/frc/robot/commands/Wrist/AutoAlignCmd.java
@@ -26,7 +26,9 @@ public class AutoAlignCmd extends CommandBase {
 
   // Called when the command is initially scheduled.
   @Override
-  public void initialize() {}
+  public void initialize() {
+    PIDo.reset();
+  }
 
   // Called every time the scheduler runs while the command is scheduled.
   @Override


### PR DESCRIPTION
* Any time a PIDController is used (ESPECIALLY with an integral term, the `reset()` method should be triggered on command initialize to zero out any internal counters from the last time the command was run.
* Setting LED display to static to avoid stop the world java pauses.